### PR TITLE
✨ グループとお気に入りカードのインタラクティブなコンポーネントを実装

### DIFF
--- a/src/app/components/card/Card.tsx
+++ b/src/app/components/card/Card.tsx
@@ -1,0 +1,55 @@
+'use client';
+import Image from 'next/image';
+import Link from 'next/link';
+import {CardProps} from '@/src/interfaces/group';
+import icons from '@/public/svgs/group';
+
+const Card = ({
+  ImageSrc,
+  ClassName,
+  ClassContent,
+  FavoriteChecked,
+}: CardProps) => {
+  return (
+    <Link href={`/${ClassName}`}>
+      <div className="border rounded-lg w-80 h-72 border-gray-300 mr-10 mb-10 hover:shadow-md active:bg-neutral-50 focus:ring focus:ring-gray-400 transform hover:scale-105 transition duration-200 ease-in-out">
+        <div className="flex justify-center items-center mt-2">
+          <div className="w-72 h-44 relative overflow-hidden">
+            <Image
+              src={ImageSrc}
+              alt={'Card Image'}
+              fill={true}
+              sizes="(max-width: 288px), (max-hight:176px)"
+              className="absolute top-0 left-0 w-full h-full object-contain"
+            />
+          </div>
+        </div>
+        <div className="flex place-content-between ms-4 mt-2">
+          <h3 className="font-bold text-lg">{ClassName}</h3>
+          {FavoriteChecked ? (
+            <Image
+              src={icons.favorite}
+              alt="favoriteChecked"
+              width={24}
+              height={24}
+              className="items-center me-2 h-6"
+            />
+          ) : (
+            <Image
+              src={icons.noneFavorite}
+              alt="noneFavoriteChecked"
+              width={24}
+              height={24}
+              className="items-center me-2 h-6"
+            />
+          )}
+        </div>
+        <p className="text-base ms-4 mt-2 me-2 overflow-hidden overflow-ellipsis whitespace-nowrap">
+          {ClassContent}
+        </p>
+      </div>
+    </Link>
+  );
+};
+
+export default Card;

--- a/src/app/components/card/index.ts
+++ b/src/app/components/card/index.ts
@@ -1,0 +1,3 @@
+import Card from './Card';
+
+export {Card};

--- a/src/app/components/group/Favorite.tsx
+++ b/src/app/components/group/Favorite.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import {useState, useEffect} from 'react';
+import {Card} from '../card';
+import logos from '@/public/images/group';
+import {GroupProps} from '@/src/interfaces/group';
+import {get, getDatabase, ref} from 'firebase/database';
+
+const Favorite = () => {
+  const [groups, setGroups] = useState<GroupProps[]>([]);
+
+  useEffect(() => {
+    const db = getDatabase();
+    const groupRef = ref(db, 'groups');
+
+    get(groupRef).then(snapshot => {
+      if (snapshot.exists()) {
+        const groupData = snapshot.val();
+        const groupList = Object.keys(groupData).map(key => {
+          return {
+            id: key,
+            name: groupData[key].name,
+            description: groupData[key].description,
+            isFavorite: groupData[key].is_favorite,
+          };
+        });
+
+        const favoriteGroups = groupList.filter(group => group.isFavorite);
+        setGroups(favoriteGroups);
+      } else {
+        console.log('No group data available');
+      }
+    });
+  }, []);
+  return (
+    <>
+      {groups.map((group, index) => (
+        <Card
+          key={index}
+          ImageSrc={logos.freee}
+          ClassName={group.name.replace('_', ' ')}
+          ClassContent={group.description}
+          FavoriteChecked={group.isFavorite}
+        />
+      ))}
+    </>
+  );
+};
+
+export default Favorite;

--- a/src/app/components/group/Group.tsx
+++ b/src/app/components/group/Group.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card } from "../card";
+import logos from "@/public/images/group";
+import { get, getDatabase, ref } from "firebase/database";
+import { GroupProps } from "@/src/interfaces/group";
+import { useRouter } from "next/navigation";
+import { useGroup } from "@/src/contexts/GroupContext";
+
+const Group = () => {
+  const [groups, setGroups] = useState<GroupProps[]>([]);
+  const { setGroupId } = useGroup();
+  const router = useRouter();
+
+  useEffect(() => {
+    const db = getDatabase();
+    const groupRef = ref(db, "groups");
+
+    get(groupRef).then((snapshot) => {
+      if (snapshot.exists()) {
+        const groupData = snapshot.val();
+        const groupList = Object.keys(groupData).map((key) => {
+          return {
+            id: key,
+            name: groupData[key].name,
+            description: groupData[key].description,
+            isFavorite: groupData[key].is_favorite,
+          };
+        });
+        setGroups(groupList);
+      } else {
+        console.log("No group data available");
+      }
+    });
+  }, []);
+
+  const handleGroupClick = (groupId: string) => {
+    setGroupId(groupId);
+    router.push(`/groups/${encodeURIComponent(groupId)}`);
+  };
+
+  return (
+    <>
+      {groups.map((group, index) => (
+        <div onClick={() => handleGroupClick(group.id)} key={index}>
+          <Card
+            ImageSrc={logos.freee}
+            ClassName={group.name.replace("_", " ")}
+            ClassContent={group.description}
+            FavoriteChecked={group.isFavorite}
+          />
+        </div>
+      ))}
+    </>
+  );
+};
+
+export default Group;

--- a/src/app/components/group/Header.tsx
+++ b/src/app/components/group/Header.tsx
@@ -1,0 +1,12 @@
+const Header = () => {
+  return (
+    <div className="mt-6">
+      <div className="flex items-center justify-between me-10">
+        <h2 className="text-black text-3xl font-medium">Groups</h2>
+      </div>
+      <div className="border border-gray-200 w-11/12 mt-2"></div>
+    </div>
+  );
+};
+
+export default Header;

--- a/src/app/components/group/Main.tsx
+++ b/src/app/components/group/Main.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import React, {useState} from 'react';
+import {Favorite, Group, Header} from '.';
+import {Dashboard, TabsMapping} from '@/src/components/dashboard';
+
+const Main = () => {
+  const tabs = ['Group', 'Favorite'];
+  const [activeTab, setActiveTab] = useState(tabs[0]);
+  const tabMapping = {
+    Group: <Group />,
+    Favorite: <Favorite />,
+  };
+
+  return (
+    <div className="flex h-full ms-10 bg-gray-200">
+      <div className="flex-grow bg-white">
+        <Header />
+        <Dashboard
+          activeTab={activeTab}
+          setActiveTab={setActiveTab}
+          tabs={tabs}
+        />
+        <div className="flex flex-wrap ms-2 mt-12 ">
+          <TabsMapping activeTab={activeTab} tabMapping={tabMapping} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Main;

--- a/src/app/components/group/index.ts
+++ b/src/app/components/group/index.ts
@@ -1,0 +1,6 @@
+import Group from './Group';
+import Favorite from './Favorite';
+import Header from './Header';
+import Main from './Main';
+
+export {Favorite, Group, Header, Main};

--- a/src/components/footer/index.ts
+++ b/src/components/footer/index.ts
@@ -1,0 +1,3 @@
+import Footer from './Footer';
+
+export {Footer};

--- a/src/interfaces/group/cardProps.ts
+++ b/src/interfaces/group/cardProps.ts
@@ -1,0 +1,8 @@
+interface CardProps {
+  ImageSrc: string;
+  ClassName: string;
+  ClassContent: string;
+  FavoriteChecked: boolean;
+}
+
+export default CardProps;

--- a/src/interfaces/group/group.ts
+++ b/src/interfaces/group/group.ts
@@ -1,0 +1,8 @@
+interface GroupProps {
+  id: string;
+  name: string;
+  description: string;
+  isFavorite: boolean;
+}
+
+export default GroupProps;

--- a/src/interfaces/group/index.ts
+++ b/src/interfaces/group/index.ts
@@ -1,0 +1,19 @@
+import InvitationProps from './invitationProps';
+import CardProps from './cardProps';
+import MemberCardProps from './memberCardProps';
+import ScheduleCardProps from './scheduleCardProps';
+import StatisticCardProps from './statisticCardProps';
+import RoleProps from './roleProps';
+import MemberProps from './member';
+import GroupProps from './group';
+
+export type {
+  InvitationProps,
+  CardProps,
+  MemberCardProps,
+  ScheduleCardProps,
+  StatisticCardProps,
+  RoleProps,
+  MemberProps,
+  GroupProps,
+};


### PR DESCRIPTION
## 🔍 このPRで解決したい問題は何ですか？

このPRでは、ユーザーがグループ情報を効果的に表示・管理できるインタラクティブなカードコンポーネントを実装しました。

## ✨ このPRで主に変わったことは何ですか？

- 新しい`Card`コンポーネントを導入し、グループ情報を動的に表示します。
- `Favorite`と`Group`コンポーネントを追加して、お気に入りとグループのデータを扱いやすくしました。
- メインダッシュボード内のレイアウトを整理するために、`Header`コンポーネントを開発しました。
- `Dashboard`と`TabsMapping`を統合することで、コンテンツを動的に表示できる`Main`コンポーネントを作成しました。

## 🔖 主な変更点以外に追加で変更された部分はありますか？

なし

## 🩺 このPRでテストや検証が必要な部分はありますか？

動作確認として、各カードの表示とクリック動作のテストが必要です。

## 📚 関連するIssueやドキュメント

* #4 

## 🖥 作動する様子

![스크린샷 2024-03-14 13 09 25](https://github.com/yuminn-k/project_freee-attendance-keeper/assets/55650732/da4a3b67-8e17-49cb-9557-be294b14e730)